### PR TITLE
fix: bump trivy-action version to fix an error

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Run Trivy scan on source code
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
#### The error info is below
```
aquasecurity/trivy info checking GitHub for tag 'v0.69.1'
aquasecurity/trivy info found version: 0.69.1 for v0.69.1/Linux/64bit
Error: Process completed with exit code 1
```
No such release tag [v0.69.1](https://github.com/aquasecurity/trivy/releases)