### PR TITLE
chore: tune container shutdown defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,9 @@ COPY --from=builder /${BUILD_DIR}/snell-server .
 COPY ./snell.sh .
 
 RUN adduser -D -H -s /bin/false ${APP_USER} && \
-    chown -R ${APP_USER} /app
+    chown -R ${APP_USER} /app && \
+    chmod +x /app/snell.sh
 
 USER ${APP_USER}
 
-CMD ["/bin/sh", "/app/snell.sh"]
+CMD ["/app/snell.sh"]

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ docker buildx build \
 
 ```bash
 # Using Docker Hub
-docker run --rm 1byte/snell-server
+docker run --stop-timeout 2 --rm 1byte/snell-server
 
 # Using GitHub Container Registry
-docker run --rm ghcr.io/waterdrops/snell-server
+docker run --stop-timeout 2 --rm ghcr.io/waterdrops/snell-server
 ```
 
 ### Specify port and PSK
@@ -104,12 +104,14 @@ docker run --rm ghcr.io/waterdrops/snell-server
 ```bash
 # Using Docker Hub
 docker run -it -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   1byte/snell-server
 
 # Using GitHub Container Registry
 docker run -it -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   ghcr.io/waterdrops/snell-server
@@ -122,6 +124,7 @@ Please refer to the `Environment Variables` section and adjust them as needed.  
 ```bash
 # Using Docker Hub
 docker run -itd -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -132,6 +135,7 @@ docker run -itd -p 8234:8234 \
 
 # Using GitHub Container Registry
 docker run -itd -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -167,6 +171,7 @@ PSK=mysecurepsk
 services:
   snell-server:
     container_name: snell-server
+    stop_grace_period: 2s
     restart: always
     image: 1byte/snell-server:latest
     ports:

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -111,10 +111,10 @@ docker buildx build \
 
 ```bash
 # 使用 Docker Hub
-docker run --rm 1byte/snell-server
+docker run --stop-timeout 2 --rm 1byte/snell-server
 
 # 使用 GitHub Container Registry
-docker run --rm ghcr.io/waterdrops/snell-server
+docker run --stop-timeout 2 --rm ghcr.io/waterdrops/snell-server
 ```
 
 ### 指定端口和 PSK
@@ -122,12 +122,14 @@ docker run --rm ghcr.io/waterdrops/snell-server
 ```bash
 # 使用 Docker Hub
 docker run -itd -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   1byte/snell-server
 
 # 使用 GitHub Container Registry
 docker run -itd -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   ghcr.io/waterdrops/snell-server
@@ -140,6 +142,7 @@ docker run -itd -p 8234:8234 \
 ```bash
 # 使用 Docker Hub
 docker run -itd -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -150,6 +153,7 @@ docker run -itd -p 8234:8234 \
 
 # 使用 GitHub Container Registry
 docker run -itd -p 8234:8234 \
+  --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
   -e IPv6=true \
@@ -185,6 +189,7 @@ PSK=mysecurepsk
 services:
   snell-server:
     container_name: snell-server
+    stop_grace_period: 2s
     restart: always
     image: 1byte/snell-server:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   snell-server:
     container_name: snell-server
+    stop_grace_period: 2s
     restart: always
     image: 1byte/snell-server:latest
     ports:

--- a/snell.sh
+++ b/snell.sh
@@ -71,13 +71,12 @@ _read_port_from_listen() {
   echo "$line" | sed -n -r 's/.*:([0-9]{1,5})[[:space:]]*$/\1/p' | head -n1
 }
 
-# --- defaults (may be overridden by config/env) ---
+# --- defaults (may be overridden by config/env / hydrate) ---
 _gen_psk() {
   # 避免 set -e 受上游 SIGPIPE 影响；ash 无 pipefail
   LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32 || true
 }
-PORT="${PORT:-$(random_port)}"
-PSK="${PSK:-$(_gen_psk)}"
+
 IPv6="${IPv6:-}"          # true|false
 OBFS="${OBFS:-}"          # off|http
 OBFS_HOST="${OBFS_HOST:-}"
@@ -161,6 +160,9 @@ print_start_info() {
 
 main() {
   hydrate_from_existing_conf || true
+  PORT="${PORT:-$(random_port)}"
+  PSK="${PSK:-$(_gen_psk)}"
+
   ensure
   write_config_if_missing
   print_start_info
@@ -175,5 +177,5 @@ main() {
   exec "$BIN" -c "$CONF"
 }
 
-main
+main "$@"
 


### PR DESCRIPTION
- Set stop_grace_period to 2s so compose stop does not use the default
10s window.
- Make snell.sh executable and run it directly from CMD.
- Defer PORT and PSK generation until after loading an existing config
so cold starts skip urandom work when values come from the file.