### PR TITLE
fix: set Denpendabot cooldown default-day to minimum of 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 0
+      default-days: 1
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
@@ -36,7 +36,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 0
+      default-days: 1
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3


### PR DESCRIPTION
Dependabot rejects default-days: 0; the schema requires a minimum value
of 1 for both docker and github-actions update entries.