### PR TITLE
feat: upgrade to Snell 6.0.0b3 with MODE env and default config writing

### DIFF
--- a/.env
+++ b/.env
@@ -3,5 +3,6 @@ PSK=mysecurepsk
 # DNS_IP_PREFERENCE=default
 # IPv6=false
 # TFO=true
+# MODE=default          # default | unshaped | unsafe-raw
 # OBFS=http
 # OBFS_HOST=gateway.icloud.com

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  VERSION: 6.0.0b2
+  VERSION: 6.0.0b3
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stable-slim AS builder
 ARG BUILD_DIR="build"
 ARG TARGETARCH
 ARG TARGETOS
-ARG SNELL_VERSION=6.0.0b2
+ARG SNELL_VERSION=6.0.0b3
 
 WORKDIR /${BUILD_DIR}
 
@@ -25,6 +25,7 @@ RUN set -eux; \
       *) echo "Unsupported TARGETARCH: ${TARGETARCH} (386/amd64/arm64 only)"; exit 1 ;; \
     esac; \
     URL="https://github.com/waterdrops/snell-server-docker/releases/download/v${SNELL_VERSION}/snell-server-v${SNELL_VERSION}-${SNELL_ARCH}.zip" && \
+    # URL="https://dl.nssurge.com/snell/snell-server-v${SNELL_VERSION}-${SNELL_ARCH}.zip" && \
     echo "Downloading ${URL}" && \
     wget "${URL}" -O snell.zip  && \
     unzip -q snell.zip && \
@@ -52,6 +53,7 @@ ENV PORT= \
     LISTEN= \
     DNS_IP_PREFERENCE= \
     IPv6= \
+    MODE= \
     OBFS= \
     OBFS_HOST= \
     TFO= 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 #
 # Quick start:
 #   make pre-push          # build + test (run before git push)
-#   make build SNELL_VERSION=6.0.0b2
+#   make build SNELL_VERSION=6.0.0b3
 #   make run               # start container for manual testing
 
 IMAGE        ?= snell-server
 TAG          ?= local
-SNELL_VERSION ?= 6.0.0b2
+SNELL_VERSION ?= 6.0.0b3
 FULL_IMAGE   := $(IMAGE):$(TAG)
 PLATFORMS    ?= linux/386,linux/amd64,linux/arm64
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Both images are identical and you can use either one based on your preference.
 - **Secure defaults**: random port and random 32-character PSK
 - **Minimal dependencies**: based on [debian:stable-slim](https://github.com/debuerreotype/docker-debian-artifacts/blob/c5f3180659db80fb676e09bd8bfd992e3df68cac/stable/slim/oci/index.json) and [busybox:stable](https://github.com/docker-library/busybox/blob/8d0487eb4336a9281dba965f5b1d656a79222142/latest-1/glibc/amd64/index.json)
 - **Conditional configuration**: only writes optional fields when values are provided
-- **Input validation**: validates IPv6 and OBFS values before startup
+- **Input validation**: validates `IPv6`, `MODE`, `DNS_IP_PREFERENCE`, and `OBFS` values before startup
 
 ## Environment Variables
 
@@ -36,9 +36,11 @@ Both images are identical and you can use either one based on your preference.
 | `LISTEN`    | `0.0.0.0:PORT`              | Listen addresses     | When `IPv6=true`, set to `0.0.0.0:PORT,[::]:PORT`; override with a custom value when `IPv6` is not `true` |
 | `DNS_IP_PREFERENCE` | `default`           | DNS IP family preference | Must be `default`, `prefer-ipv4`, `prefer-ipv6`, `ipv4-only`, or `ipv6-only` |
 | `IPv6`      | Not set (optional)          | Enable IPv6          | Must be `true` or `false` if provided |
-| `OBFS`      | Not set (optional)          | Obfuscation mode     | Must be `off` or `http` if provided   |
+| `MODE`      | Not set (optional)          | Snell v6 crypto/obfuscation mode (beta 3+) | Must be `default`, `unshaped`, or `unsafe-raw` if provided |
+| `OBFS`      | Not set (optional)          | Obfuscation mode (legacy) | Must be `off` or `http` if provided   |
 | `OBFS_HOST` | Not set (optional)          | Obfuscation host     | Only used when `OBFS=http`            |
 | `TFO`       | `true`                      | Enable TCP Fast Open | Boolean                               |
+
 
 ## Configuration Behavior
 
@@ -47,29 +49,31 @@ The server uses conditional configuration writing:
 - **IPv6**: Only written to config if `IPv6` environment variable is set; when `IPv6=true`, `listen` is set to `0.0.0.0:PORT,[::]:PORT` for dual-stack binding
 - **LISTEN**: Written to config as `listen`; defaults to `0.0.0.0:PORT`, or dual-stack when `IPv6=true`
 - **DNS_IP_PREFERENCE**: Always written to config as `dns-ip-preference` (default: `default`)
+- **MODE**: Only written to config if `MODE` environment variable is set
 - **OBFS**: Only written to config if `OBFS` environment variable is set
 - **OBFS_HOST**: Only written to config if `OBFS=http` and `OBFS_HOST` is set
 - **Existing config file**: If `snell-server.conf` already exists (e.g., mounted via volume), it will be used as-is and the script will skip generating a new one
 
 ## Docker Images
 
-Published tags (example for Snell `6.0.0b2`):
+Published tags (example for Snell `6.0.0b3`):
 
 | Tag | Description |
 | --- | --- |
 | `latest` | Latest build from `main` |
 | `6` | Latest image for Snell v6 |
-| `6.0.0b2` | Exact Snell version (no `v` prefix) |
+| `6.0.0b3` | Exact Snell version (no `v` prefix) |
 
 ```bash
 # Docker Hub
 docker pull 1byte/snell-server
 docker pull 1byte/snell-server:6
-docker pull 1byte/snell-server:6.0.0b2
+docker pull 1byte/snell-server:6.0.0b3
 
 # GitHub Container Registry
 docker pull ghcr.io/waterdrops/snell-server
 docker pull ghcr.io/waterdrops/snell-server:6
+docker pull ghcr.io/waterdrops/snell-server:6.0.0b3
 ```
 
 ## Build the Image
@@ -134,7 +138,7 @@ docker run -it -p 8234:8234 \
 
 ### Complete configuration example
 
-Please refer to the `Environment Variables` section and adjust them as needed.  For example, you can disable obfuscation by setting: `OBFS=off`
+Please refer to the `Environment Variables` section and adjust them as needed. For example, set `MODE=unshaped` for higher throughput (client must use the same mode).
 
 ```bash
 # Using Docker Hub
@@ -142,9 +146,9 @@ docker run -itd -p 8234:8234 \
   --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
+  -e MODE=default \
+  -e DNS_IP_PREFERENCE=default \
   -e IPv6=true \
-  -e OBFS=http \
-  -e OBFS_HOST=gateway.icloud.com \
   -e TFO=false \
   1byte/snell-server
 
@@ -153,9 +157,9 @@ docker run -itd -p 8234:8234 \
   --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
+  -e MODE=default \
+  -e DNS_IP_PREFERENCE=default \
   -e IPv6=true \
-  -e OBFS=http \
-  -e OBFS_HOST=gateway.icloud.com \
   -e TFO=false \
   ghcr.io/waterdrops/snell-server
 ```
@@ -176,6 +180,8 @@ PORT=8234
 PSK=mysecurepsk
 # IPv6=false
 # TFO=true
+# dns-ip-preference = default # default | prefer-ipv4 | prefer-ipv6 | ipv4-only | ipv6-only
+# MODE=default          # default | unshaped | unsafe-raw
 # OBFS=http
 # OBFS_HOST=gateway.icloud.com
 ```
@@ -196,6 +202,8 @@ services:
       PSK: "${PSK}"
       # IPv6: "${IPv6}"
       # TFO: "${TFO}"
+      # dns-ip-preference = default # default | prefer-ipv4 | prefer-ipv6 | ipv4-only | ipv6-only
+      # MODE: "${MODE}"      # default | unshaped | unsafe-raw
       # OBFS: "${OBFS}"        # Set to "false" to disable; `http` enables it
       # OBFS_HOST: "${OBFS_HOST}"
     # volumes:
@@ -237,9 +245,9 @@ To learn more about `Surge Policy Groups`, see Surge Policy Group documentation[
 
 ```vim
 [Proxy]
-home = snell, YOUR_FQDN or YOUR_PUBLIC_IP, ${PORT}, psk=${PSK}, version=5, reuse=true
-# If obfuscation is enabled:
-# home = snell, YOUR_PUBLIC_IP or YOUR_FQDN, YOUR_PORT, psk=YOUR_PSK, version=5, obfs=http, obfs-host=YOUR_OBFS_HOST, reuse=true, tfo=true
+home = snell, YOUR_FQDN or YOUR_PUBLIC_IP, ${PORT}, psk=${PSK}, version=6, reuse=true
+# mode=unshaped for higher throughput (must match server MODE):
+# home = snell, YOUR_PUBLIC_IP or YOUR_FQDN, YOUR_PORT, psk=YOUR_PSK, version=6, mode=unshaped, reuse=true, tfo=true
 ...
 [Proxy Group]
 # Define a policy group named `🏠Home` of type `subnet`.  
@@ -263,6 +271,7 @@ The server validates all input values before starting:
 - **Invalid PORT**: Must be an integer between 1025 and 65535
 - **Invalid IPv6**: Must be `true` or `false` if provided
 - **Invalid DNS_IP_PREFERENCE**: Must be `default`, `prefer-ipv4`, `prefer-ipv6`, `ipv4-only`, or `ipv6-only`
+- **Invalid MODE**: Must be `default`, `unshaped`, or `unsafe-raw` if provided
 - **Invalid OBFS**: Must be `off` or `http` if provided
 
 If any validation fails, the server will display an error message and exit with code 1.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -29,7 +29,7 @@
 - **安全默认值**：随机端口和随机 32 字符 PSK
 - **最小依赖**：基于[debian:stable-slim](https://github.com/debuerreotype/docker-debian-artifacts/blob/c5f3180659db80fb676e09bd8bfd992e3df68cac/stable/slim/oci/index.json) and [busybox:stable](https://github.com/docker-library/busybox/blob/8d0487eb4336a9281dba965f5b1d656a79222142/latest-1/glibc/amd64/index.json) 
 - **条件配置**：仅在提供值时写入可选字段
-- **输入验证**：在启动前验证 IPv6 和 OBFS 值
+- **输入验证**：在启动前验证 IPv6、MODE、DNS_IP_PREFERENCE 和 OBFS 值
 
 ## 贡献
 
@@ -54,9 +54,11 @@
 | `LISTEN`    | `0.0.0.0:PORT`             | 监听地址      | `IPv6=true` 时为 `0.0.0.0:PORT,[::]:PORT`；未启用 IPv6 时可自定义 |
 | `DNS_IP_PREFERENCE` | `default`          | DNS 解析 IP 地址族偏好 | 必须是 `default`、`prefer-ipv4`、`prefer-ipv6`、`ipv4-only` 或 `ipv6-only` |
 | `IPv6`      | 未设置（可选）              | 启用 IPv6     | 如果提供，必须是 `true` 或 `false` |
-| `OBFS`      | 未设置（可选）              | 混淆模式      | 如果提供，必须是 `off` 或 `http` |
+| `MODE`      | 未设置（可选）              | Snell v6 加密/混淆模式（beta 3+） | 如果提供，必须是 `default`、`unshaped` 或 `unsafe-raw` |
+| `OBFS`      | 未设置（可选）              | 混淆模式（旧版） | 如果提供，必须是 `off` 或 `http` |
 | `OBFS_HOST` | 未设置（可选）              | 混淆主机      | 仅在 `OBFS=http` 时使用       |
 | `TFO`       | `true`                      | 启用 TCP Fast Open | 布尔值                    |
+
 
 ## 配置行为
 
@@ -65,29 +67,31 @@
 - **IPv6**：仅在设置 `IPv6` 环境变量时写入配置；当 `IPv6=true` 时，`listen` 设为 `0.0.0.0:PORT,[::]:PORT` 以实现双栈监听
 - **LISTEN**：写入配置为 `listen`；默认为 `0.0.0.0:PORT`，`IPv6=true` 时为双栈地址
 - **DNS_IP_PREFERENCE**：始终写入配置为 `dns-ip-preference`（默认：`default`）
+- **MODE**：仅在设置 `MODE` 环境变量时写入配置
 - **OBFS**：仅在设置 `OBFS` 环境变量时写入配置
 - **OBFS_HOST**：仅在 `OBFS=http` 且设置 `OBFS_HOST` 时写入配置
 - **已有配置文件**：如果已经存在 `snell-server.conf`（例如通过 volume 挂载），脚本将直接使用该文件并跳过生成
 
 ## Docker 镜像
 
-发布标签（以 Snell `6.0.0b2` 为例）：
+发布标签（以 Snell `6.0.0b3` 为例）：
 
 | 标签 | 说明 |
 | --- | --- |
 | `latest` | `main` 分支最新构建 |
 | `6` | Snell v6 大版本最新镜像 |
-| `6.0.0b2` | 精确版本（无 `v` 前缀） |
+| `6.0.0b3` | 精确版本（无 `v` 前缀） |
 
 ```bash
 # Docker Hub
 docker pull 1byte/snell-server
 docker pull 1byte/snell-server:6
-docker pull 1byte/snell-server:6.0.0b2
+docker pull 1byte/snell-server:6.0.0b3
 
 # GitHub Container Registry
 docker pull ghcr.io/waterdrops/snell-server
 docker pull ghcr.io/waterdrops/snell-server:6
+docker pull ghcr.io/waterdrops/snell-server:6.0.0b3
 ```
 
 ## 构建镜像
@@ -152,7 +156,7 @@ docker run -itd -p 8234:8234 \
 
 ### 完整配置示例
 
-请参考 `环境变量` 部分并根据需要调整。例如，可以通过设置 `OBFS=off` 来禁用混淆。
+请参考 `环境变量` 部分并根据需要调整。例如，可设置 `MODE=unshaped` 以提升吞吐（客户端须使用相同 mode）。
 
 ```bash
 # 使用 Docker Hub
@@ -160,9 +164,9 @@ docker run -itd -p 8234:8234 \
   --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
+  -e MODE=default \
+  -e DNS_IP_PREFERENCE=default \
   -e IPv6=true \
-  -e OBFS=http \
-  -e OBFS_HOST=gateway.icloud.com \
   -e TFO=false \
   1byte/snell-server
 
@@ -171,9 +175,9 @@ docker run -itd -p 8234:8234 \
   --stop-timeout 2 \
   -e PORT=8234 \
   -e PSK=mysecurepsk \
+  -e MODE=default \
+  -e DNS_IP_PREFERENCE=default \
   -e IPv6=true \
-  -e OBFS=http \
-  -e OBFS_HOST=gateway.icloud.com \
   -e TFO=false \
   ghcr.io/waterdrops/snell-server
 ```
@@ -194,6 +198,8 @@ PORT=8234
 PSK=mysecurepsk
 # IPv6=false
 # TFO=true
+# dns-ip-preference = default # default | prefer-ipv4 | prefer-ipv6 | ipv4-only | ipv6-only
+# MODE=default          # default | unshaped | unsafe-raw
 # OBFS=http
 # OBFS_HOST=gateway.icloud.com
 ```
@@ -214,6 +220,8 @@ services:
       PSK: "${PSK}"
       # IPv6: "${IPv6}"
       # TFO: "${TFO}"
+      # dns-ip-preference = default # default | prefer-ipv4 | prefer-ipv6 | ipv4-only | ipv6-only
+      # MODE: "${MODE}"      # default | unshaped | unsafe-raw
       # OBFS: "${OBFS}"        # 设置为 "false" 禁用；`http` 启用
       # OBFS_HOST: "${OBFS_HOST}"
     # volumes:
@@ -255,9 +263,9 @@ docker compose up -d
 
 ```vim
 [Proxy]
-home = snell, YOUR_FQDN or YOUR_PUBLIC_IP, ${PORT}, psk=${PSK}, version=5, reuse=true
-# 如果启用了混淆 
-# home = snell, YOUR_PUBLIC_IP or YOUR_FQDN, YOUR_PORT, psk=YOUR_PSK, version=5, obfs=http, obfs-host=YOUR_OBFS_HOST, reuse=true, tfo=true
+home = snell, YOUR_FQDN or YOUR_PUBLIC_IP, ${PORT}, psk=${PSK}, version=6, reuse=true
+# mode=unshaped 可提升吞吐（须与服务端 MODE 一致）：
+# home = snell, YOUR_PUBLIC_IP or YOUR_FQDN, YOUR_PORT, psk=YOUR_PSK, version=6, mode=unshaped, reuse=true, tfo=true
 ...
 [Proxy Group]
 # 定义一个名为 `🏠Home` 的 `subnet` 类型策略组。
@@ -280,6 +288,7 @@ OR,((DOMAIN,plex.YOUR_DOMAIN), (DOMAIN,vw.YOUR_DOMAIN), (DOMAIN,gitea.YOUR_DOMAI
 - **无效的 PORT**：必须是 1025 到 65535 之间的整数
 - **无效的 IPv6**：如果提供，必须是 `true` 或 `false`
 - **无效的 DNS_IP_PREFERENCE**：必须是 `default`、`prefer-ipv4`、`prefer-ipv6`、`ipv4-only` 或 `ipv6-only`
+- **无效的 MODE**：如果提供，必须是 `default`、`unshaped` 或 `unsafe-raw`
 - **无效的 OBFS**：如果提供，必须是 `off` 或 `http`
 
 如果任何验证失败，服务器将显示错误消息并以代码 1 退出。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       # DNS_IP_PREFERENCE: "default"
       # IPv6: "false"
       # TFO: "true"
+      # MODE: "default"     # default | unshaped | unsafe-raw
       # OBFS: "http"        # Set to "false" to disable; any other value enables it
       # OBFS_HOST: "gateway.icloud.com"
     # volumes:

--- a/snell.sh
+++ b/snell.sh
@@ -78,11 +78,12 @@ _gen_psk() {
 }
 
 IPv6="${IPv6:-}"                    # true|false
+MODE="${MODE:-}"                    # default|unshaped|unsafe-raw
 OBFS="${OBFS:-}"                    # off|http
 OBFS_HOST="${OBFS_HOST:-}"
 TFO="${TFO:-true}"                  # true|false
 LISTEN="${LISTEN:-}"
-DNS_IP_PREFERENCE="${DNS_IP_PREFERENCE:-default}"
+DNS_IP_PREFERENCE="${DNS_IP_PREFERENCE:-}"
 
 # Prefer existing config: populate variables from it if present
 hydrate_from_existing_conf() {
@@ -92,6 +93,7 @@ hydrate_from_existing_conf() {
   v="$(_read_port_from_listen     || true)"; [ -n "${v:-}" ] && PORT="$v"
   v="$(_read_kv psk               || true)"; [ -n "${v:-}" ] && PSK="$v"
   v="$(_read_kv ipv6              || true)"; [ -n "${v:-}" ] && IPv6="$v"
+  v="$(_read_kv mode              || true)"; [ -n "${v:-}" ] && MODE="$v"
   v="$(_read_kv obfs              || true)"; [ -n "${v:-}" ] && OBFS="$v"
   v="$(_read_kv obfs-host         || true)"; [ -n "${v:-}" ] && OBFS_HOST="$v"
   v="$(_read_kv tfo               || true)"; [ -n "${v:-}" ] && TFO="$v"
@@ -127,6 +129,9 @@ ensure() {
   if [ -n "${IPv6:-}" ] && [ "$IPv6" != "true" ] && [ "$IPv6" != "false" ]; then
     _die "Invalid IPv6: $IPv6 (must be 'true' or 'false')"
   fi
+  if [ -n "${MODE:-}" ] && [ "$MODE" != "default" ] && [ "$MODE" != "unshaped" ] && [ "$MODE" != "unsafe-raw" ]; then
+    _die "Invalid MODE: $MODE (must be 'default', 'unshaped', or 'unsafe-raw')"
+  fi
   if [ -n "${OBFS:-}" ] && [ "$OBFS" != "off" ] && [ "$OBFS" != "http" ]; then
     _die "Invalid OBFS: $OBFS (must be 'off' or 'http')"
   fi
@@ -153,8 +158,9 @@ write_config_if_missing() {
     echo "[snell-server]"
     echo "listen = ${LISTEN}"
     echo "psk = ${PSK}"
-    echo "dns-ip-preference = ${DNS_IP_PREFERENCE}"
+    echo "dns-ip-preference = ${DNS_IP_PREFERENCE:-default}"
     [ -n "${IPv6:-}" ] && echo "ipv6 = ${IPv6}"
+    echo "mode = ${MODE:-default}"
     if [ -n "${OBFS:-}" ]; then
       echo "obfs = ${OBFS}"
       if [ "${OBFS}" = "http" ] && [ -n "${OBFS_HOST:-}" ]; then
@@ -170,8 +176,9 @@ print_start_info() {
   printf 'PORT: %s\n' "$PORT"
   printf 'LISTEN: %s\n' "$LISTEN"
   printf 'PSK: %s\n' "$PSK"
-  printf 'DNS_IP_PREFERENCE: %s\n' "$DNS_IP_PREFERENCE"
   [ -n "${IPv6:-}" ] && printf 'IPv6: %s\n' "$IPv6"
+  [ -n "${DNS_IP_PREFERENCE:-}" ] && printf 'DNS_IP_PREFERENCE: %s\n' "$DNS_IP_PREFERENCE"
+  [ -n "${MODE:-}" ] && printf 'MODE: %s\n' "$MODE"
   [ -n "${OBFS:-}" ] && printf 'OBFS: %s\n' "$OBFS"
   if [ "${OBFS:-}" = "http" ] && [ -n "${OBFS_HOST:-}" ]; then
     printf 'OBFS_HOST: %s\n' "$OBFS_HOST"
@@ -183,7 +190,6 @@ main() {
   hydrate_from_existing_conf || true
   PORT="${PORT:-$(random_port)}"
   PSK="${PSK:-$(_gen_psk)}"
-  DNS_IP_PREFERENCE="${DNS_IP_PREFERENCE:-default}"
   LISTEN="$(resolve_listen)"
 
   ensure


### PR DESCRIPTION
- Add MODE (default/unshaped/unsafe-raw) configuration for Snell v6 beta 3
- Write explicit default values for mode and dns-ip-preference when unset
- Omit those fields from startup logs unless explicitly provided
- Update docs and Surge client examples for version 6